### PR TITLE
Fix ElasticsearchDeprecationWarning for using the typeless endpoints

### DIFF
--- a/inhale.py
+++ b/inhale.py
@@ -81,7 +81,7 @@ def elasticPost(fileinfo):
     es = Elasticsearch()
     es.indices.create(index='inhaled', ignore=400)
     try:
-        es.index(index="inhaled", doc_type="file", body=fileinfo)
+        es.index(index="inhaled", body=fileinfo)
         print("{}{} [+] Added {}{}{}!".format(side,e,cCYAN,fileinfo["filename"],e))
     except:
         print("{}{} {}[!] Could not add {}{} - Try passing -b to disable binwalk signatures!".format(side,e,cRED,fileinfo["filename"],e))


### PR DESCRIPTION
Removed doc_type as it is not needed anymore (unsupported in ES8).
I don't exactly know if this will work with all elasticsearch versions, but at least it will support ES7 and up.